### PR TITLE
chore: purge old sethsimmons handle/branding

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Seth For Privacy (@sethsimmons)
+Copyright (c) 2021 Seth For Privacy (@sethforprivacy)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
   monerod:
-    image: sethsimmons/simple-monerod:latest
+    image: ghcr.io/sethforprivacy/simple-monerod:latest
     restart: unless-stopped
     container_name: monerod
     volumes:
@@ -18,7 +18,7 @@ services:
       - "--prune-blockchain"
   
   monero-wallet-rpc:
-    image: sethsimmons/simple-monero-wallet-rpc:latest
+    image: ghcr.io/sethforprivacy/simple-monero-wallet-rpc:latest
     restart: unless-stopped
     container_name: monero-wallet-rpc
     volumes:


### PR DESCRIPTION
Purges references to the old `sethsimmons` handle / `sethsimmons.me` blog as part of rebranding to Seth For Privacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)