### PR TITLE
Update Monero to v0.18.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 # Alpine specifics from https://github.com/cornfeedhobo/docker-monero/blob/f96711415f97af1fc9364977d1f5f5ecd313aad0/Dockerfile
 
 # Set Monero branch or tag to build
-ARG MONERO_BRANCH=v0.18.4.6
+ARG MONERO_BRANCH=v0.18.5.0
 
 # Set the proper HEAD commit hash for the given branch/tag in MONERO_BRANCH
-ARG MONERO_COMMIT_HASH=dbcc7d212c094bd1a45f7291dbb99a4b4627a96d
+ARG MONERO_COMMIT_HASH=3ca4c30f73fe22d16a46cfba122556437da3618d
 
 # Select Alpine 3 for the build image base
 FROM alpine:3.24 AS build


### PR DESCRIPTION
## Summary
Bumps the built Monero release from v0.18.4.6 to **v0.18.5.0** (latest upstream).

- `MONERO_BRANCH` → `v0.18.5.0`
- `MONERO_COMMIT_HASH` → `3ca4c30f73fe22d16a46cfba122556437da3618d` — verified against `refs/tags/v0.18.5.0^{}` (dereferenced commit) and matches the hash used by simple-monerod-docker.

## Testing
Built locally for linux/arm64 from source; the resulting `monero-wallet-rpc --version` reports `Monero 'Fluorine Fermi' (v0.18.5.0-release)`. The repo's `build-image-on-push.yml` will test-build this on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)