### PR TITLE
Add Renovate config for automated version bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:enableMajor",
+    "mergeConfidence:all-badges",
+    ":disableRateLimiting",
+    ":semanticCommits"
+  ],
+  "rebaseWhen": "conflicted",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_VERSION=(?<currentValue>.*)(\\sARG .*?_CHECKSUM=(?<currentDigest>.*))?\\s",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_BRANCH=(?<currentValue>.*)(\\sARG .*?_COMMIT_HASH=(?<currentDigest>.*))?\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{/if}}"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Mirrors the simple-monerod-docker Renovate setup so upstream version bumps are proposed automatically and tested by CI.

- adds `.github/renovate.json` (identical to monerod's — custom managers for `*_BRANCH`/`*_COMMIT_HASH` and `*_VERSION`/`*_CHECKSUM` ARG pairs)
- annotates the MONERO, expat, libunbound, and fixuid version ARGs with `# renovate:` comments
- places `MONERO_BRANCH`/`MONERO_COMMIT_HASH` on adjacent lines and unquotes `FIXUID_VERSION` so the custom-manager regex captures both value and digest

## Merge order
**Stacked on `wr-align`** (base branch), because the annotations target the aligned ARG format (`*_CHECKSUM`, `R_2_6_4`/`release-1.22.0`). Merge the alignment PR first; GitHub will retarget this PR to `main` automatically.

## Note
`config:recommended` lets Renovate also manage GitHub Actions here (this repo currently has a Dependabot Actions group + open PR #134). After this lands you may want to drop `.github/dependabot.yml` to avoid duplicate Actions PRs, as in monerod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)