### PR TITLE
feat: bump Monero to v0.18.5.1, fix login shell, enable Renovate for Dockerfile ARGs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 # Alpine specifics from https://github.com/cornfeedhobo/docker-monero/blob/f96711415f97af1fc9364977d1f5f5ecd313aad0/Dockerfile
 
 # Set Monero branch or tag to build
-ARG MONERO_BRANCH=v0.18.5.0
+ARG MONERO_BRANCH=v0.18.5.1
 
 # Set the proper HEAD commit hash for the given branch/tag in MONERO_BRANCH
-ARG MONERO_COMMIT_HASH=3ca4c30f73fe22d16a46cfba122556437da3618d
+ARG MONERO_COMMIT_HASH=4f92268d7c16741cfb41e5bbe2aa46cc260a9ea5
 
 # Select Alpine 3 for the build image base
 FROM alpine:3.24.1 AS build
@@ -155,7 +155,7 @@ RUN set -ex && apk add --update --no-cache \
     zeromq
 
 # Add user and setup directories for monerod
-RUN set -ex && adduser -Ds /bin/bash monero \
+RUN set -ex && adduser -Ds /bin/ash monero \
     && mkdir -p /home/monero/.bitmonero \
     && chown -R monero:monero /home/monero/.bitmonero
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # Initial base from https://github.com/leonardochaia/docker-monerod/blob/master/src/Dockerfile
 # Alpine specifics from https://github.com/cornfeedhobo/docker-monero/blob/f96711415f97af1fc9364977d1f5f5ecd313aad0/Dockerfile
 
-# Set Monero branch or tag to build
+# renovate: datasource=github-releases depName=monero-project/monero
 ARG MONERO_BRANCH=v0.18.5.1
-
-# Set the proper HEAD commit hash for the given branch/tag in MONERO_BRANCH
 ARG MONERO_COMMIT_HASH=4f92268d7c16741cfb41e5bbe2aa46cc260a9ea5
 
 # Select Alpine 3 for the build image base
@@ -94,6 +92,7 @@ ENV USE_SINGLE_BUILDDIR=1
 ENV BOOST_DEBUG=1
 
 # Build expat, a dependency for libunbound
+# renovate: datasource=github-release-attachments depName=libexpat/libexpat versioning=semver-coerced
 ARG EXPAT_VERSION=R_2_6_4
 ARG EXPAT_CHECKSUM=8dc480b796163d4436e6f1352e71800a774f73dbae213f1860b60607d2a83ada
 RUN set -ex && EXPAT_SEMVER="$(echo ${EXPAT_VERSION} | sed 's/R_//;s/_/./g')" && \
@@ -108,6 +107,7 @@ RUN set -ex && EXPAT_SEMVER="$(echo ${EXPAT_VERSION} | sed 's/R_//;s/_/./g')" &&
 
 # Build libunbound for static builds
 WORKDIR /tmp
+# renovate: datasource=github-release-attachments depName=NLnetLabs/unbound versioning=semver-coerced
 ARG LIBUNBOUND_VERSION=release-1.22.0
 ARG LIBUNBOUND_CHECKSUM=4e32a36d57cda666b1c8ee02185ba73462330452162d1b9c31a5b91a853ba946
 RUN set -ex && wget "https://github.com/NLnetLabs/unbound/archive/refs/tags/${LIBUNBOUND_VERSION}.tar.gz"  && \
@@ -169,7 +169,8 @@ ARG TARGETARCH
 # Checksums must be updated manually when bumping FIXUID_VERSION (upstream publishes no checksum file)
 ARG FIXUID_AMD64_CHECKSUM=8c47f64ec4eec60e79871796ea4097ead919f7fcdedace766da9510b78c5fa14
 ARG FIXUID_ARM64_CHECKSUM=827e0b480c38470b5defb84343be7bb4e85b9efcbf3780ac779374e8b040a969
-ARG FIXUID_VERSION="0.6.0"
+# renovate: datasource=github-releases depName=boxboat/fixuid
+ARG FIXUID_VERSION=0.6.0
 RUN set -ex && case ${TARGETARCH:-amd64} in \
         "arm64") FIXUID_ARCH="arm64"; FIXUID_CHECKSUM="${FIXUID_ARM64_CHECKSUM}" ;; \
         "amd64") FIXUID_ARCH="amd64"; FIXUID_CHECKSUM="${FIXUID_AMD64_CHECKSUM}" ;; \


### PR DESCRIPTION
## Summary

- Bump `MONERO_BRANCH` to **v0.18.5.1** and `MONERO_COMMIT_HASH` to `4f92268d7c16741cfb41e5bbe2aa46cc260a9ea5`, matching sethforprivacy/simple-monerod-docker.
- Fix the final-stage `adduser -Ds /bin/bash monero` → `/bin/ash`: bash is never installed in the final image, so the monero user's login shell pointed at a nonexistent binary. The entrypoint uses `/bin/sh`, so nothing depended on bash.
- **Enable Renovate for the Dockerfile ARGs**: renovate.json already ships the custom regex manager, but the Dockerfile had no `# renovate:` marker comments, so Renovate never opened version-bump PRs here. This adds the same annotations as simple-monerod-docker:
  - `monero-project/monero` (github-releases) — `MONERO_COMMIT_HASH` moved adjacent to `MONERO_BRANCH` so the regex captures it as the digest and bumps version + hash together
  - `libexpat/libexpat` and `NLnetLabs/unbound` (github-release-attachments, semver-coerced) — checksum ARGs captured as digests
  - `boxboat/fixuid` (github-releases) — version unquoted (`"0.6.0"` → `0.6.0`) so the regex captures a clean value; checksums intentionally stay manual and fail closed (upstream publishes no checksum file)

## Verification

- Commit hash verified against the upstream tag: `git ls-remote https://github.com/monero-project/monero 'refs/tags/v0.18.5.1^{}'` → `4f92268d7c16741cfb41e5bbe2aa46cc260a9ea5`
- The Dockerfile's own `git rev-parse HEAD` check enforces the same match at build time
- The identical version/hash pair already builds successfully in simple-monerod-docker CI
- Ran renovate.json's exact `matchStrings` regexes against the modified Dockerfile — all four dependencies captured with the expected datasource, version, and digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)