### PR TITLE
feat: add healthcheck that honors --rpc-login credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -163,6 +163,9 @@ RUN set -ex && adduser -Ds /bin/ash monero \
 COPY --chmod=0755 entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]
 
+# Copy healthcheck script
+COPY --chmod=0755 healthcheck.sh /healthcheck.sh
+
 # Install and configure fixuid and switch to MONERO_USER
 ARG MONERO_USER="monero"
 ARG TARGETARCH
@@ -195,6 +198,9 @@ WORKDIR /home/${MONERO_USER}/wallet
 
 # Expose default wallet-rpc port
 EXPOSE 18083
+
+# Add HEALTHCHECK against json_rpc get_version, honoring --rpc-login credentials if set
+HEALTHCHECK --interval=30s --timeout=5s CMD /healthcheck.sh || exit 1
 
 # Start monerod with sane defaults that are overridden by user input (if applicable)
 CMD ["--wallet-dir=/home/monero/wallet", "--rpc-bind-port=18083"]

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Healthcheck for monero-wallet-rpc that supports --rpc-login
+# The RPC port and credentials are read from the running daemon's command
+# line (PID 1), so the check automatically follows the container's
+# configuration without any compose-file overrides.
+set -eu
+
+# Print the value of a daemon argument, handling both "--flag=value" and
+# "--flag value" forms. Prints nothing if the flag is absent.
+get_arg() {
+    tr '\0' '\n' < /proc/1/cmdline | awk -v flag="$1" '
+        prev == flag { print; exit }
+        index($0, flag "=") == 1 { print substr($0, length(flag) + 2); exit }
+        { prev = $0 }
+    '
+}
+
+RPC_LOGIN="$(get_arg --rpc-login)"
+RPC_PORT="$(get_arg --rpc-bind-port)"
+RPC_URL="http://127.0.0.1:${RPC_PORT:-18083}/json_rpc"
+RPC_BODY='{"jsonrpc":"2.0","id":"0","method":"get_version"}'
+
+if [ -n "${RPC_LOGIN}" ]; then
+    curl --fail --silent --digest --user "${RPC_LOGIN}" \
+        --header 'Content-Type: application/json' --data "${RPC_BODY}" "${RPC_URL}"
+else
+    # Credentials may still be set via --config-file, which cannot be read
+    # here; a 401 response proves the RPC server is alive regardless.
+    status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+        --header 'Content-Type: application/json' --data "${RPC_BODY}" "${RPC_URL}")"
+    [ "${status}" = "200" ] || [ "${status}" = "401" ]
+fi


### PR DESCRIPTION
## Summary

Companion to sethforprivacy/simple-monerod-docker#238 (which fixes sethforprivacy/simple-monerod-docker#205).

This image shipped no `HEALTHCHECK` at all. Since `monero-wallet-rpc` requires either `--rpc-login` or `--disable-rpc-login`, a naive curl-based healthcheck would hit the same 401 problem reported in the monerod repo — so this adds one that handles credentials from the start:

- `healthcheck.sh` POSTs `json_rpc` `get_version` to the wallet-rpc port
- Reads `/proc/1/cmdline` (the entrypoint `exec`s the daemon via fixuid, so PID 1 is the daemon itself) to find `--rpc-login` — both `=` and space-separated forms — and authenticates with `curl --digest` when present
- Honors a custom `--rpc-bind-port` (default 18083, matching the image CMD)
- When credentials are supplied via `--config-file` (not readable from the command line), a 401 response is treated as alive, since it proves the RPC server is up

## Verification

Tested against the published `ghcr.io/sethforprivacy/simple-monero-wallet-rpc:latest` image (real monero-wallet-rpc, script mounted in):

| Scenario | Result |
|---|---|
| `--rpc-login=test:pass123` | ✅ digest auth, real `get_version` JSON returned |
| `--disable-rpc-login` | ✅ |
| RPC unreachable | ❌ fails as it should |

🤖 Generated with [Claude Code](https://claude.com/claude-code)